### PR TITLE
[FEAT] 유저 활동데이터 페이지 저장그룹/투표내역 API 연동

### DIFF
--- a/src/apis/activity.ts
+++ b/src/apis/activity.ts
@@ -1,6 +1,7 @@
 import { authProxyAPI } from "./customAxios";
 import { fetchWithAuth } from "./fetchWithAuth";
 import type { SavedGroupResponse, SavedPlacesResponse } from "@/types/activity";
+import qs from "qs";
 
 export const getBookmarkedGroups = async () => {
   try {
@@ -35,6 +36,31 @@ export const getBookmarkedPlaces = async (group_id: string) => {
     }
   } catch (error) {
     console.error("Failed to fetch bookmarked places:", error);
-    return null;
+    return {
+      group_id: "",
+      group_name: "",
+      icon: "",
+      total: 0,
+      places: [],
+    };
+  }
+};
+
+export const deleteBookmarkedPlace = async (
+  groupId: string,
+  placeId: string[]
+) => {
+  try {
+    const queryString = qs.stringify(
+      { place_ids: placeId },
+      { arrayFormat: "repeat" }
+    );
+    const response = await authProxyAPI.delete(
+      `/bookmark/group/${groupId}/places?${queryString}`
+    );
+    return response.data.data;
+  } catch (error) {
+    console.error("Failed to delete bookmarked place:", error);
+    throw error;
   }
 };

--- a/src/apis/activity.ts
+++ b/src/apis/activity.ts
@@ -64,3 +64,21 @@ export const deleteBookmarkedPlace = async (
     throw error;
   }
 };
+
+export const moveBookmarkedPlace = async (
+  sourceGroupId: string,
+  targetGroupIds: string[],
+  placeId: string[]
+) => {
+  try {
+    const response = await authProxyAPI.patch(`/bookmark/place/move`, {
+      source_group: sourceGroupId,
+      target_groups: targetGroupIds,
+      place_id: placeId,
+    });
+    return response.data.data;
+  } catch (error) {
+    console.error("Failed to move bookmarked place:", error);
+    throw error;
+  }
+};

--- a/src/apis/activity.ts
+++ b/src/apis/activity.ts
@@ -1,6 +1,10 @@
 import { authProxyAPI } from "./customAxios";
 import { fetchWithAuth } from "./fetchWithAuth";
-import type { SavedGroupResponse, SavedPlacesResponse } from "@/types/activity";
+import type {
+  SavedGroupResponse,
+  SavedPlacesResponse,
+  VotedActivityResponse,
+} from "@/types/activity";
 import qs from "qs";
 
 export const getBookmarkedGroups = async () => {
@@ -79,6 +83,23 @@ export const moveBookmarkedPlace = async (
     return response.data.data;
   } catch (error) {
     console.error("Failed to move bookmarked place:", error);
+    throw error;
+  }
+};
+
+export const getUserVotedActivity = async () => {
+  try {
+    let data;
+    if (typeof window === "undefined") {
+      data = await fetchWithAuth<VotedActivityResponse>(`/users/activity/vote`);
+      return data.data;
+    } else {
+      const response =
+        await authProxyAPI.get<VotedActivityResponse>(`/users/activity/vote`);
+      return response.data.data;
+    }
+  } catch (error) {
+    console.error("Failed to fetch user voted activity:", error);
     throw error;
   }
 };

--- a/src/apis/activity.ts
+++ b/src/apis/activity.ts
@@ -15,7 +15,7 @@ export const getBookmarkedGroups = async () => {
     }
   } catch (error) {
     console.error("Failed to fetch bookmarked groups:", error);
-    return null;
+    return { total: 0, groups: [] };
   }
 };
 

--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -15,6 +15,32 @@ export const createGroup = async (data: {
   }
 };
 
+export const updateGroup = async (
+  groupId: string,
+  data: {
+    group_name: string;
+    icon: string;
+  }
+) => {
+  try {
+    const response = await authProxyAPI.put(`/bookmark/group/${groupId}`, data);
+    return response.data.data;
+  } catch (error) {
+    console.error("Group 수정 실패:", error);
+    throw error;
+  }
+};
+
+export const deleteGroup = async (groupId: string) => {
+  try {
+    const response = await authProxyAPI.delete(`/bookmark/group/${groupId}`);
+    return response.data.data;
+  } catch (error) {
+    console.error("Group 삭제 실패:", error);
+    throw error;
+  }
+};
+
 export const getPlaceGroup = async (placeId: string) => {
   const response = await authProxyAPI.get(`/bookmark/group/${placeId}`);
   return response.data.data;

--- a/src/app/(user)/saved/page.tsx
+++ b/src/app/(user)/saved/page.tsx
@@ -1,15 +1,22 @@
-import { getBookmarkedGroups } from "@/apis/activity";
+import {
+  HydrationBoundary,
+  dehydrate,
+  QueryClient,
+} from "@tanstack/react-query";
 import SavedPageTemplate from "@/components/templates/SavedPageTemplate/SavedPageTemplate";
+import { getBookmarkedGroups } from "@/apis/activity";
 
 export default async function SavedPage() {
-  const data = await getBookmarkedGroups();
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["bookmarkedGroups"],
+    queryFn: getBookmarkedGroups,
+  });
+  const dehydratedState = dehydrate(queryClient);
+
   return (
-    <SavedPageTemplate
-      total={data?.total ?? 0}
-      groups={data?.groups ?? []}
-      // onDeleteClick={() => {}}
-      // onEdit={() => {}}
-      // onCreate={() => {}}
-    />
+    <HydrationBoundary state={dehydratedState}>
+      <SavedPageTemplate />
+    </HydrationBoundary>
   );
 }

--- a/src/app/(user)/voted/page.tsx
+++ b/src/app/(user)/voted/page.tsx
@@ -1,43 +1,21 @@
+import { getUserVotedActivity } from "@/apis/activity";
 import VotedPageTemplate from "@/components/templates/VotedPageTemplate/VotedPageTemplate";
-import { VotedActivityInfo } from "@/types/activity";
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 
-const dummy: VotedActivityInfo[] = [
-  {
-    place_id: "1",
-    place_name: "place_name",
-    category: "category",
-    platform: "naver",
-    reasons: [
-      "reason1",
-      "reason2",
-      "reason3",
-      "reason4",
-      "reason5",
-      "reason6",
-      "reason7",
-      "reason8",
-      "reason9",
-      "reason10",
-    ],
-    voted_date: "2025-07-07",
-  },
-  {
-    place_id: "2",
-    place_name: "place_name2",
-    category: "category2",
-    platform: "naver",
-    reasons: ["reason1", "reason2"],
-    voted_date: "2025-07-07",
-  },
-  {
-    place_id: "3",
-    place_name: "place_name3",
-    category: "category3",
-    platform: "kakao",
-    reasons: ["reason1", "reason2"],
-    voted_date: "2025-07-07",
-  },
-];
 export default async function VotedPage() {
-  return <VotedPageTemplate items={dummy} />;
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["votedActivity"],
+    queryFn: getUserVotedActivity,
+  });
+  const dehydratedState = dehydrate(queryClient);
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <VotedPageTemplate />
+    </HydrationBoundary>
+  );
 }

--- a/src/components/organisms/ActivityList/VotedActivityList/VotedActivityList.tsx
+++ b/src/components/organisms/ActivityList/VotedActivityList/VotedActivityList.tsx
@@ -36,27 +36,40 @@ export default function VotedActivityList({
             <div className="caption-m-semibold text-texticon-onnormal-midemp px-[16px] py-[4px]">
               {year}년 {month}월
             </div>
-            {groupItems.map((item) => {
+            {groupItems.map((item, index) => {
               const dateInfo = parseKoreanDateInfo(item.voted_date);
+              const isToday =
+                dateInfo.isToday && index === groupItems.length - 1;
               return (
                 <ListItem
                   key={item.place_id}
-                  className="h-[138px] flex-row px-[16px] py-[12px] justify-start gap-[16px]"
+                  className="h-full flex-row px-[16px] py-[12px] justify-start gap-[16px]"
                   onClick={() => onItemClick(item)}
                 >
                   <div
                     className={cn(
-                      "relative h-full aspect-[60/138] bg-surface-normal-container-b10 rounded-[4px] body-m-semibold flex flex-col items-center justify-center"
+                      "relative flex-shrink-0 w-[60px] h-[138px] bg-surface-normal-container-b10 rounded-[8px] body-m-semibold flex flex-col items-center justify-center",
+                      isToday && "border border-border-primary-500"
                     )}
                   >
-                    <p className="text-texticon-onnormal-highestemp">
+                    <p
+                      className={cn(
+                        "text-texticon-onnormal-highestemp",
+                        isToday && "text-brand-primary-main"
+                      )}
+                    >
                       {dateInfo.date}
                     </p>
-                    <p className="text-texticon-onnormal-lowestemp">
+                    <p
+                      className={cn(
+                        "text-texticon-onnormal-lowestemp",
+                        isToday && "text-brand-primary-main"
+                      )}
+                    >
                       {dateInfo.day[0]}
                     </p>
                   </div>
-                  <div className="flex flex-col gap-[8px] w-full">
+                  <div className="flex flex-col justify-between py-[12px] w-full">
                     <p className="caption-m-semibold text-texticon-onnormal-lowemp">
                       {item.category}
                     </p>

--- a/src/components/organisms/ActivityList/VotedActivityList/VotedActivityList.tsx
+++ b/src/components/organisms/ActivityList/VotedActivityList/VotedActivityList.tsx
@@ -3,73 +3,109 @@ import { cn } from "@/utils/cn";
 import { VotedActivityInfo } from "@/types/activity";
 import Icon from "@/components/atoms/Icon/Icon";
 import { colors } from "@/styles/colors";
+import { REASON_LABELS } from "@/types/platformMatch";
+import { parseKoreanDateInfo } from "@/utils/date";
 
 interface VotedActivityListProps {
   items: VotedActivityInfo[];
   onItemClick: (item: VotedActivityInfo) => void;
 }
 
+function groupByYearMonth(items: VotedActivityInfo[]) {
+  const grouped: Record<string, VotedActivityInfo[]> = {};
+  items.forEach((item) => {
+    const { year, month } = parseKoreanDateInfo(item.voted_date);
+    const key = `${year}-${month}`;
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(item);
+  });
+  return grouped;
+}
+
 export default function VotedActivityList({
   items,
   onItemClick,
 }: VotedActivityListProps) {
+  const grouped = groupByYearMonth(items);
   return (
     <List className="flex flex-col pb-[100px] w-full overflow-x-hidden">
-      {items.map((item) => (
-        <ListItem
-          key={item.place_id}
-          className="h-[138px] flex-row px-[16px] py-[12px] justify-start gap-[16px]"
-          onClick={() => onItemClick(item)}
-        >
-          <div className="relative h-full aspect-[60/138] bg-surface-normal-container-b10 rounded-[4px] body-m-semibold flex flex-col items-center justify-center">
-            {/* TODO: 투표 날짜 표시 필요 */}
-            <p className="text-texticon-onnormal-highestemp">18</p>
-            <p className="text-texticon-onnormal-lowestemp">토</p>
-          </div>
-          <div className="flex flex-col gap-[8px] w-full">
-            <p className="caption-m-semibold text-texticon-onnormal-lowemp">
-              {item.category}
-            </p>
-            <p className="body-m-semibold text-texticon-onnormal-highestemp">
-              {item.place_name}
-            </p>
-
-            {/* TODO: 라벨 컴포넌트 분리 필요 */}
-            <p className="flex items-center w-fit gap-[2px] px-[8px] py-[2px] border border-border-normal-lowestemp rounded-[4px]">
-              <span
-                className={cn(
-                  "caption-m-semibold",
-                  item.platform === "naver"
-                    ? "text-brand-naver-main"
-                    : "text-brand-kakao-blue"
-                )}
-              >
-                {item.platform === "naver" ? "네이버" : "카카오"}
-              </span>
-              <span className="caption-s-regular text-texticon-onnormal-midemp">
-                에 투표했어요
-              </span>
-            </p>
-
-            {/* TODO: 라벨 컴포넌트 분리 필요 */}
-            <div className="flex gap-[8px] w-full overflow-x-auto scrollbar-hide pr-[80px]">
-              {item.reasons.map((reason, index) => (
-                <p
-                  key={index}
-                  className="flex items-center gap-[4px] px-[8px] py-[2px] rounded-[2px] caption-s-regular text-texticon-onnormal-main-500 bg-surface-normal-container-b50"
-                >
-                  <span>{reason}</span>
-                  <Icon
-                    icon="Check"
-                    size={12}
-                    stroke={colors.TextIcon.OnNormal["Main 500"]}
-                  />
-                </p>
-              ))}
+      {Object.entries(grouped).map(([yearMonth, groupItems]) => {
+        const [year, month] = yearMonth.split("-");
+        return (
+          <div key={yearMonth}>
+            <div className="caption-m-semibold text-texticon-onnormal-midemp px-[16px] py-[4px]">
+              {year}년 {month}월
             </div>
+            {groupItems.map((item) => {
+              const dateInfo = parseKoreanDateInfo(item.voted_date);
+              return (
+                <ListItem
+                  key={item.place_id}
+                  className="h-[138px] flex-row px-[16px] py-[12px] justify-start gap-[16px]"
+                  onClick={() => onItemClick(item)}
+                >
+                  <div
+                    className={cn(
+                      "relative h-full aspect-[60/138] bg-surface-normal-container-b10 rounded-[4px] body-m-semibold flex flex-col items-center justify-center"
+                    )}
+                  >
+                    <p className="text-texticon-onnormal-highestemp">
+                      {dateInfo.date}
+                    </p>
+                    <p className="text-texticon-onnormal-lowestemp">
+                      {dateInfo.day[0]}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-[8px] w-full">
+                    <p className="caption-m-semibold text-texticon-onnormal-lowemp">
+                      {item.category}
+                    </p>
+                    <p className="body-m-semibold text-texticon-onnormal-highestemp">
+                      {item.place_name}
+                    </p>
+
+                    {/* TODO: 라벨 컴포넌트 분리 필요 */}
+                    <p className="flex items-center w-fit gap-[2px] px-[8px] py-[2px] border border-border-normal-lowestemp rounded-[4px]">
+                      <span
+                        className={cn(
+                          "caption-m-semibold",
+                          item.platform === "NAVER"
+                            ? "text-brand-naver-main"
+                            : "text-brand-kakao-blue"
+                        )}
+                      >
+                        {item.platform === "NAVER" ? "네이버" : "카카오"}
+                      </span>
+                      <span className="caption-s-regular text-texticon-onnormal-midemp">
+                        에 투표했어요
+                      </span>
+                    </p>
+
+                    {/* TODO: 라벨 컴포넌트 분리 필요 */}
+                    <div className="flex gap-[8px] w-full overflow-x-auto scrollbar-hide pr-[80px]">
+                      {item.reasons.map((reason, index) => (
+                        <p
+                          key={index}
+                          className="flex items-center gap-[4px] px-[8px] py-[2px] rounded-[2px] caption-s-regular text-texticon-onnormal-main-500 bg-surface-normal-container-b50 whitespace-nowrap"
+                        >
+                          <span className="whitespace-nowrap">
+                            {REASON_LABELS[reason]}
+                          </span>
+                          <Icon
+                            icon="Check"
+                            size={12}
+                            stroke={colors.TextIcon.OnNormal["Main 500"]}
+                          />
+                        </p>
+                      ))}
+                    </div>
+                  </div>
+                </ListItem>
+              );
+            })}
           </div>
-        </ListItem>
-      ))}
+        );
+      })}
     </List>
   );
 }

--- a/src/components/organisms/GroupBottomSheet/GroupWithInputBottomSheet/GroupWithInputBottomSheet.tsx
+++ b/src/components/organisms/GroupBottomSheet/GroupWithInputBottomSheet/GroupWithInputBottomSheet.tsx
@@ -104,7 +104,7 @@ export default function GroupWithInputBottomSheet({
             variant="primary"
             fullWidth
             className="h-[56px]"
-            disabled={!groupName}
+            disabled={!groupName || !selectedColor}
             onClick={onDone}
           >
             완료

--- a/src/components/organisms/GroupBottomSheet/GroupWithInputBottomSheet/useGroupWithInputBottomSheet.ts
+++ b/src/components/organisms/GroupBottomSheet/GroupWithInputBottomSheet/useGroupWithInputBottomSheet.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from "react";
+
+export function useGroupWithInputBottomSheet() {
+  const [groupName, setGroupName] = useState("");
+  const [selectedIcon, setSelectedIcon] = useState("");
+
+  const resetGroupInput = useCallback(() => {
+    setGroupName("");
+    setSelectedIcon("");
+  }, []);
+
+  return {
+    groupName,
+    setGroupName,
+    selectedIcon,
+    setSelectedIcon,
+    resetGroupInput,
+  };
+}

--- a/src/components/organisms/GroupBottomSheet/index.ts
+++ b/src/components/organisms/GroupBottomSheet/index.ts
@@ -1,2 +1,3 @@
 export { default as GroupDefaultListBottomSheet } from "./GroupDefaultListBottomSheet/GroupDefaultListBottomSheet";
 export { default as GroupWithInputBottomSheet } from "./GroupWithInputBottomSheet/GroupWithInputBottomSheet";
+export { useGroupWithInputBottomSheet } from "./GroupWithInputBottomSheet/useGroupWithInputBottomSheet";

--- a/src/components/organisms/PlaceSaveModal/GroupSaveModal.tsx
+++ b/src/components/organisms/PlaceSaveModal/GroupSaveModal.tsx
@@ -43,7 +43,6 @@ export default function GroupSaveModal({
       const savedGroups = groups
         .filter((group: Group) => group.is_saved)
         .map((group: Group) => group.group_id);
-      console.log(groups);
       setSelectedGroup(savedGroups);
 
       // 초기 선택 상태 설정

--- a/src/components/organisms/PlaceSaveModal/PlaceSaveModal.tsx
+++ b/src/components/organisms/PlaceSaveModal/PlaceSaveModal.tsx
@@ -38,6 +38,8 @@ export default function PlaceSaveModal({
       queryClient.invalidateQueries({
         queryKey: ["isPlaceSaved", placeId],
       });
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedGroups"] });
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedPlaces"] });
     },
   });
 

--- a/src/components/templates/SavedGroupDetailTemplate/SavedGroupDetailTemplate.tsx
+++ b/src/components/templates/SavedGroupDetailTemplate/SavedGroupDetailTemplate.tsx
@@ -20,6 +20,7 @@ import {
   useBookmarkedGroupsQuery,
   useBookmarkedPlacesQuery,
   useDeleteBookmarkedPlaceMutation,
+  useMoveBookmarkedPlaceMutation,
 } from "@/hooks/queries";
 
 type SortType = "recent" | "name";
@@ -58,6 +59,7 @@ export default function SavedGroupDetailTemplate({ id }: { id: string }) {
   const deleteBookmarkedPlaceMutation = useDeleteBookmarkedPlaceMutation(
     group_id ?? ""
   );
+  const moveBookmarkedPlaceMutation = useMoveBookmarkedPlaceMutation();
 
   const handleDelete = async () => {
     await deleteBookmarkedPlaceMutation.mutateAsync(selected);
@@ -241,7 +243,15 @@ export default function SavedGroupDetailTemplate({ id }: { id: string }) {
             title="그룹 선택"
             groups={groups?.groups ?? []}
             onClose={close}
-            onDone={() => {
+            onDone={async (targetGroupId) => {
+              if (!group_id || !targetGroupId || selected.length === 0) return;
+              await moveBookmarkedPlaceMutation.mutateAsync({
+                sourceGroupId: group_id,
+                targetGroupIds: [targetGroupId],
+                placeIds: selected,
+              });
+              reset();
+              setIsEditMode(false);
               close();
             }}
           />

--- a/src/components/templates/SavedGroupDetailTemplate/SavedGroupDetailTemplate.tsx
+++ b/src/components/templates/SavedGroupDetailTemplate/SavedGroupDetailTemplate.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { usePortal } from "@/hooks/usePortal";
 import { colors } from "@/styles/colors";
 import Icon from "@/components/atoms/Icon/Icon";
@@ -12,10 +12,15 @@ import IconButton from "@/components/molecules/IconButton/IconButton";
 import { ContextMenu } from "@/components/molecules/ContextMenu";
 import { AlertModal } from "@/components/molecules/Modal";
 import { SavedGroupDetailList } from "@/components/organisms/ActivityList";
-import { sortByDate, sortByName } from "@/utils/sort";
-
-import type { GroupInfo, PlaceInfo } from "@/types/activity";
 import { GroupDefaultListBottomSheet } from "@/components/organisms/GroupBottomSheet";
+import { sortByDate, sortByName } from "@/utils/sort";
+import type { PlaceInfo } from "@/types/activity";
+import { useSelection, useSheetState, useSort } from "@/hooks";
+import {
+  useBookmarkedGroupsQuery,
+  useBookmarkedPlacesQuery,
+  useDeleteBookmarkedPlaceMutation,
+} from "@/hooks/queries";
 
 type SortType = "recent" | "name";
 
@@ -24,76 +29,41 @@ const SORT_LABELS: Record<SortType, string> = {
   name: "장소명 순",
 };
 
-interface SavedGroupDetailTemplateProps {
-  items: PlaceInfo[];
-  groups: GroupInfo[];
-  groupId: string;
-  groupName: string;
-  total: number;
-  groupIcon: string;
-  onDeleteClick?: (items: string[]) => void;
-  onMoveClick?: (params: {
-    fromGroupId: string;
-    placeIds: string[];
-    toGroupId: string;
-  }) => void;
-}
+const sorters: Record<SortType, (arr: PlaceInfo[]) => PlaceInfo[]> = {
+  recent: (arr) => sortByDate(arr, (p) => p.saved_at, "desc"),
+  name: (arr) => sortByName(arr, (p) => p.place_name),
+} as const;
 
-export default function SavedGroupDetailTemplate({
-  items,
-  groups,
-  groupId,
-  groupName,
-  groupIcon,
-  total,
-  onDeleteClick,
-  onMoveClick,
-}: SavedGroupDetailTemplateProps) {
+export default function SavedGroupDetailTemplate({ id }: { id: string }) {
   const createPortal = usePortal();
   const router = useRouter();
 
-  const [sortType, setSortType] = useState<SortType>("recent");
+  const { data: groups } = useBookmarkedGroupsQuery({
+    queryKey: ["bookmarkedGroups"],
+  });
+  const { data } = useBookmarkedPlacesQuery(id);
+  const { group_id, group_name, icon, total, places } = data ?? {};
+
+  const { sortKey, setSortKey, sortedItems } = useSort<PlaceInfo, SortType>(
+    places ?? [],
+    sorters,
+    "recent"
+  );
+  const { selected, setSelected, toggle, toggleAll, reset } =
+    useSelection<PlaceInfo>(places ?? [], (p) => p.place_id);
+  const { sheet, open, close } = useSheetState<"delete" | "move">();
+
   const [isEditMode, setIsEditMode] = useState(false);
-  const [selectedItems, setSelectedItems] = useState<string[]>([]);
-  const [currentSheet, setCurrentSheet] = useState<"move" | "delete" | null>(
-    null
+
+  const deleteBookmarkedPlaceMutation = useDeleteBookmarkedPlaceMutation(
+    group_id ?? ""
   );
 
-  const sortMethods: Record<SortType, (arr: PlaceInfo[]) => PlaceInfo[]> = {
-    recent: (arr) => sortByDate(arr, (p) => p.saved_at, "desc"),
-    name: (arr) => sortByName(arr, (p) => p.place_name),
+  const handleDelete = async () => {
+    await deleteBookmarkedPlaceMutation.mutateAsync(selected);
+    reset();
+    close();
   };
-
-  const sortedItems = useMemo(() => {
-    return sortMethods[sortType](items);
-  }, [items, sortType]);
-
-  const openSheet = useCallback((sheetType: "move" | "delete") => {
-    setCurrentSheet(sheetType);
-  }, []);
-
-  const closeSheet = useCallback(() => {
-    setCurrentSheet(null);
-  }, []);
-
-  const deleteEditMode = useCallback(() => {
-    setSelectedItems([]);
-    setIsEditMode(false);
-  }, []);
-
-  const toggleAllItemsSelection = useCallback(() => {
-    setSelectedItems(
-      selectedItems.length === items.length
-        ? []
-        : items.map((item) => item.place_id)
-    );
-  }, [items, selectedItems]);
-
-  const toggleItemSelection = useCallback((item: string) => {
-    setSelectedItems((prev) =>
-      prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item]
-    );
-  }, []);
 
   return (
     <div className="flex flex-col flex-1 h-full w-full bg-surface-normal-container0">
@@ -104,7 +74,7 @@ export default function SavedGroupDetailTemplate({
           startIcon={!isEditMode && <Icon icon="Back" />}
           endIcon={isEditMode && <Icon icon="Exit" />}
           onClickStartIcon={() => router.back()}
-          onClickEndIcon={deleteEditMode}
+          onClickEndIcon={() => setIsEditMode(false)}
           fullWidth
           className="border-b border-border-normal-lowemp"
         />
@@ -117,12 +87,12 @@ export default function SavedGroupDetailTemplate({
                 <Icon
                   icon="Radio"
                   fill={
-                    selectedItems.length === items.length
+                    selected.length === (places?.length ?? 0)
                       ? colors.TextIcon.OnNormal["Main 500"]
                       : undefined
                   }
                   stroke={
-                    selectedItems.length === items.length
+                    selected.length === (places?.length ?? 0)
                       ? colors.TextIcon.OnNormal.White
                       : undefined
                   }
@@ -131,7 +101,7 @@ export default function SavedGroupDetailTemplate({
               text="전체 선택"
               className="body-s-regular text-texticon-onnormal-midemp"
               gap={16}
-              onClick={toggleAllItemsSelection}
+              onClick={toggleAll}
             />
           </div>
         )}
@@ -141,9 +111,9 @@ export default function SavedGroupDetailTemplate({
           <>
             {/* 그룹 정보 */}
             <div className="flex flex-col px-[16px] py-[24px]">
-              <Icon icon="Group" fill={groupIcon} />
+              <Icon icon="Group" fill={icon} />
               <p className="body-l-semibold text-texticon-onnormal-highestemp mt-[12px] mb-[8px]">
-                {groupName}
+                {group_name}
               </p>
               <p className="body-s-regular space-x-[4px] text-texticon-onnormal-lowemp">
                 <span>저장된 가게</span>
@@ -162,7 +132,7 @@ export default function SavedGroupDetailTemplate({
                   <IconButton
                     {...props}
                     gap={4}
-                    text={SORT_LABELS[sortType]}
+                    text={SORT_LABELS[sortKey]}
                     className="body-s-regular"
                     endIcon={
                       <Icon
@@ -177,13 +147,13 @@ export default function SavedGroupDetailTemplate({
                 items={[
                   {
                     label: SORT_LABELS.recent,
-                    onClick: () => setSortType("recent"),
-                    selected: sortType === "recent",
+                    onClick: () => setSortKey("recent"),
+                    selected: sortKey === "recent",
                   },
                   {
                     label: SORT_LABELS.name,
-                    onClick: () => setSortType("name"),
-                    selected: sortType === "name",
+                    onClick: () => setSortKey("name"),
+                    selected: sortKey === "name",
                   },
                 ]}
               />
@@ -191,7 +161,7 @@ export default function SavedGroupDetailTemplate({
                 variant="neutral"
                 className="button-s-medium py-[5px] px-[8px]"
                 onClick={() => {
-                  setSelectedItems([]);
+                  setSelected([]);
                   setIsEditMode(true);
                 }}
               >
@@ -206,18 +176,18 @@ export default function SavedGroupDetailTemplate({
       <div className="flex flex-col flex-1">
         <SavedGroupDetailList
           items={sortedItems}
-          selectedItems={selectedItems}
+          selectedItems={selected}
           isEditMode={isEditMode}
           onItemClick={(item) => {
             if (isEditMode) {
-              toggleItemSelection(item.place_id);
+              toggle(item.place_id);
             } else {
               router.push(`/place/${item.place_id}`);
             }
           }}
           onDeleteClick={(item) => {
-            toggleItemSelection(item.place_id);
-            openSheet("delete");
+            toggle(item.place_id);
+            open("delete");
           }}
         />
       </div>
@@ -229,9 +199,9 @@ export default function SavedGroupDetailTemplate({
             variant="primary"
             className="button-l-semibold py-[16px]"
             fullWidth
-            disabled={selectedItems.length === 0}
+            disabled={selected.length === 0}
             onClick={() => {
-              openSheet("move");
+              open("move");
             }}
           >
             이동
@@ -240,9 +210,9 @@ export default function SavedGroupDetailTemplate({
             variant="primary"
             className="button-l-semibold py-[16px]"
             fullWidth
-            disabled={selectedItems.length === 0}
+            disabled={selected.length === 0}
             onClick={() => {
-              openSheet("delete");
+              open("delete");
             }}
           >
             삭제
@@ -251,34 +221,28 @@ export default function SavedGroupDetailTemplate({
       )}
 
       {/* 관련 모달 */}
-      {currentSheet === "delete" &&
+      {sheet === "delete" &&
         createPortal(
           <AlertModal
-            isOpen={currentSheet === "delete"}
-            onClose={closeSheet}
+            isOpen={sheet === "delete"}
+            onClose={close}
             title="선택한 가게를 삭제할까요?"
             leftButtonText="취소"
             rightButtonText="삭제"
-            onLeftButtonClick={closeSheet}
-            onRightButtonClick={() => {
-              onDeleteClick?.(selectedItems);
-            }}
+            onLeftButtonClick={close}
+            onRightButtonClick={handleDelete}
+            // isLoading={deleteBookmarkedPlaceMutation.isPending} // 필요시 주석 해제
           />
         )}
 
-      {currentSheet === "move" &&
+      {sheet === "move" &&
         createPortal(
           <GroupDefaultListBottomSheet
             title="그룹 선택"
-            groups={groups}
-            onClose={closeSheet}
-            onDone={(targetGroupId) => {
-              onMoveClick?.({
-                fromGroupId: groupId,
-                placeIds: selectedItems,
-                toGroupId: targetGroupId,
-              });
-              closeSheet();
+            groups={groups?.groups ?? []}
+            onClose={close}
+            onDone={() => {
+              close();
             }}
           />
         )}

--- a/src/components/templates/SavedPageTemplate/SavedPageTemplate.tsx
+++ b/src/components/templates/SavedPageTemplate/SavedPageTemplate.tsx
@@ -6,6 +6,7 @@ import { usePortal } from "@/hooks/usePortal";
 import { colors } from "@/styles/colors";
 import Icon from "@/components/atoms/Icon/Icon";
 import Button from "@/components/atoms/Button/Button";
+import Toast from "@/components/atoms/Toast/Toast";
 import DefaultHeader from "@/components/molecules/Header/DefaultHeader";
 import IconButton from "@/components/molecules/IconButton/IconButton";
 import { AlertModal } from "@/components/molecules/Modal";
@@ -73,10 +74,19 @@ export default function SavedPageTemplate({ onEdit }: SavedPageTemplateProps) {
     resetGroupInput,
   } = useGroupWithInputBottomSheet();
 
+  const [toast, setToast] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: "",
+  });
+
   const closeSheet = useCallback(() => {
     resetGroupInput();
     close();
   }, [close, resetGroupInput]);
+
+  const showToast = useCallback((message: string) => {
+    setToast({ open: true, message });
+  }, []);
 
   return (
     <div className="flex flex-col flex-1 h-full w-full bg-surface-normal-container0">
@@ -206,6 +216,7 @@ export default function SavedPageTemplate({ onEdit }: SavedPageTemplateProps) {
             onClose={closeSheet}
             onDone={() => {
               closeSheet();
+              showToast("그룹이 수정되었습니다");
               if (selectedItem) onEdit?.(selectedItem);
             }}
           />
@@ -227,9 +238,16 @@ export default function SavedPageTemplate({ onEdit }: SavedPageTemplateProps) {
                 icon: selectedIcon,
               });
               closeSheet();
+              showToast("새로운 그룹이 생성되었습니다");
             }}
           />
         )}
+      <Toast
+        message={toast.message}
+        icon={<Icon icon="Complete" />}
+        isOpen={toast.open}
+        onClose={() => setToast((prev) => ({ ...prev, open: false }))}
+      />
     </div>
   );
 }

--- a/src/components/templates/SavedPageTemplate/SavedPageTemplate.tsx
+++ b/src/components/templates/SavedPageTemplate/SavedPageTemplate.tsx
@@ -21,6 +21,7 @@ import type { GroupInfo } from "@/types/activity";
 import {
   useBookmarkedGroupsQuery,
   useCreateGroupMutation,
+  useDeleteGroupMutation,
 } from "@/hooks/queries";
 import { useSort, useSheetState } from "@/hooks";
 
@@ -43,10 +44,7 @@ interface SavedPageTemplateProps {
   onEdit?: (item: GroupInfo) => void;
 }
 
-export default function SavedPageTemplate({
-  onDeleteClick,
-  onEdit,
-}: SavedPageTemplateProps) {
+export default function SavedPageTemplate({ onEdit }: SavedPageTemplateProps) {
   const createPortal = usePortal();
   const router = useRouter();
 
@@ -54,6 +52,7 @@ export default function SavedPageTemplate({
     queryKey: ["bookmarkedGroups"],
   });
   const createGroupMutation = useCreateGroupMutation();
+  const deleteGroupMutation = useDeleteGroupMutation();
 
   const groups = useMemo(() => data?.groups ?? [], [data]);
   const total = useMemo(() => data?.total ?? 0, [data]);
@@ -188,8 +187,10 @@ export default function SavedPageTemplate({
             leftButtonText="취소"
             rightButtonText="삭제"
             onLeftButtonClick={closeSheet}
-            onRightButtonClick={() => {
-              if (selectedItem) onDeleteClick?.(selectedItem.group_id);
+            onRightButtonClick={async () => {
+              if (!selectedItem) return;
+              await deleteGroupMutation.mutateAsync(selectedItem.group_id);
+              closeSheet();
             }}
           />
         )}

--- a/src/components/templates/SavedPageTemplate/SavedPageTemplate.tsx
+++ b/src/components/templates/SavedPageTemplate/SavedPageTemplate.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useMemo } from "react";
 import { usePortal } from "@/hooks/usePortal";
 import { colors } from "@/styles/colors";
 import Icon from "@/components/atoms/Icon/Icon";
@@ -11,11 +11,18 @@ import IconButton from "@/components/molecules/IconButton/IconButton";
 import { AlertModal } from "@/components/molecules/Modal";
 import { ContextMenu } from "@/components/molecules/ContextMenu";
 import { SavedGroupList } from "@/components/organisms/ActivityList";
-import { GroupWithInputBottomSheet } from "@/components/organisms/GroupBottomSheet";
+import {
+  GroupWithInputBottomSheet,
+  useGroupWithInputBottomSheet,
+} from "@/components/organisms/GroupBottomSheet";
 import { sortByDate, sortByName } from "@/utils/sort";
-import { useMemo } from "react";
 
 import type { GroupInfo } from "@/types/activity";
+import {
+  useBookmarkedGroupsQuery,
+  useCreateGroupMutation,
+} from "@/hooks/queries";
+import { useSort, useSheetState } from "@/hooks";
 
 type SortType = "recent" | "name" | "group";
 
@@ -25,56 +32,52 @@ const SORT_LABELS: Record<SortType, string> = {
   group: "그룹 추가 순",
 };
 
+const sorters = {
+  recent: (arr: GroupInfo[]) => sortByDate(arr, (g) => g.create_at, "desc"),
+  name: (arr: GroupInfo[]) => sortByName(arr, (g) => g.group_name),
+  group: (arr: GroupInfo[]) => sortByDate(arr, (g) => g.create_at),
+} as const;
+
 interface SavedPageTemplateProps {
-  total: number;
-  groups: GroupInfo[];
   onDeleteClick?: (group_id: string) => void;
   onEdit?: (item: GroupInfo) => void;
 }
 
 export default function SavedPageTemplate({
-  total,
-  groups,
   onDeleteClick,
   onEdit,
 }: SavedPageTemplateProps) {
   const createPortal = usePortal();
   const router = useRouter();
-  const [sortType, setSortType] = useState<SortType>("recent");
-  const [currentSheet, setCurrentSheet] = useState<
-    "delete" | "edit" | "create" | null
-  >(null);
+
+  const { data, isLoading } = useBookmarkedGroupsQuery({
+    queryKey: ["bookmarkedGroups"],
+  });
+  const createGroupMutation = useCreateGroupMutation();
+
+  const groups = useMemo(() => data?.groups ?? [], [data]);
+  const total = useMemo(() => data?.total ?? 0, [data]);
+
+  const { sortKey, setSortKey, sortedItems } = useSort<GroupInfo, SortType>(
+    groups,
+    sorters,
+    "recent"
+  );
+
+  const { sheet, open, close } = useSheetState<"delete" | "edit" | "create">();
   const [selectedItem, setSelectedItem] = useState<GroupInfo | null>(null);
-  const [groupName, setGroupName] = useState("");
-  const [selectedColor, setSelectedColor] = useState("");
-
-  const sortMethods: Record<SortType, (arr: GroupInfo[]) => GroupInfo[]> = {
-    recent: (arr) => sortByDate(arr, (g) => g.create_at, "desc"),
-    name: (arr) => sortByName(arr, (g) => g.group_name),
-    group: (arr) => sortByDate(arr, (g) => g.create_at),
-  };
-
-  const sortedGroups = useMemo(() => {
-    return sortMethods[sortType](groups);
-  }, [groups, sortType]);
-
-  const openSheet = useCallback((sheetType: "delete" | "edit" | "create") => {
-    setCurrentSheet(sheetType);
-  }, []);
+  const {
+    groupName,
+    setGroupName,
+    selectedIcon,
+    setSelectedIcon,
+    resetGroupInput,
+  } = useGroupWithInputBottomSheet();
 
   const closeSheet = useCallback(() => {
-    setGroupName("");
-    setSelectedColor("");
-    setCurrentSheet(null);
-  }, []);
-
-  const handleGroupNameChange = useCallback((value: string) => {
-    setGroupName(value);
-  }, []);
-
-  const handleColorSelect = useCallback((color: string) => {
-    setSelectedColor(color);
-  }, []);
+    resetGroupInput();
+    close();
+  }, [close, resetGroupInput]);
 
   return (
     <div className="flex flex-col flex-1 h-full w-full bg-surface-normal-container0">
@@ -101,7 +104,7 @@ export default function SavedPageTemplate({
               <IconButton
                 {...props}
                 gap={4}
-                text={SORT_LABELS[sortType]}
+                text={SORT_LABELS[sortKey]}
                 className="body-s-regular"
                 endIcon={
                   <Icon
@@ -116,18 +119,18 @@ export default function SavedPageTemplate({
             items={[
               {
                 label: SORT_LABELS.recent,
-                onClick: () => setSortType("recent"),
-                selected: sortType === "recent",
+                onClick: () => setSortKey("recent"),
+                selected: sortKey === "recent",
               },
               {
                 label: SORT_LABELS.name,
-                onClick: () => setSortType("name"),
-                selected: sortType === "name",
+                onClick: () => setSortKey("name"),
+                selected: sortKey === "name",
               },
               {
                 label: SORT_LABELS.group,
-                onClick: () => setSortType("group"),
-                selected: sortType === "group",
+                onClick: () => setSortKey("group"),
+                selected: sortKey === "group",
               },
             ]}
           />
@@ -136,22 +139,28 @@ export default function SavedPageTemplate({
 
       {/* 저장 그룹 리스트 */}
       <div className="flex-1">
-        <SavedGroupList
-          items={sortedGroups}
-          onItemClick={(item) => {
-            router.push(`/saved/${item.group_id}`);
-          }}
-          onDeleteClick={(item) => {
-            setSelectedItem(item);
-            openSheet("delete");
-          }}
-          onEdit={(item) => {
-            setSelectedItem(item);
-            setGroupName(item.group_name);
-            setSelectedColor(item.icon);
-            openSheet("edit");
-          }}
-        />
+        {isLoading ? (
+          <div className="flex justify-center items-center h-full">
+            로딩 중...
+          </div>
+        ) : (
+          <SavedGroupList
+            items={sortedItems}
+            onItemClick={(item) => {
+              router.push(`/saved/${item.group_id}`);
+            }}
+            onDeleteClick={(item) => {
+              setSelectedItem(item);
+              open("delete");
+            }}
+            onEdit={(item) => {
+              setSelectedItem(item);
+              setGroupName(item.group_name);
+              setSelectedIcon(item.icon);
+              open("edit");
+            }}
+          />
+        )}
       </div>
 
       {/* 새로운 그룹 만들기 버튼 */}
@@ -161,7 +170,7 @@ export default function SavedPageTemplate({
           className="button-l-semibold py-[16px]"
           fullWidth
           onClick={() => {
-            openSheet("create");
+            open("create");
           }}
         >
           새로운 그룹 만들기
@@ -169,10 +178,10 @@ export default function SavedPageTemplate({
       </div>
 
       {/* 관련 모달 및 바텀시트 */}
-      {currentSheet === "delete" &&
+      {sheet === "delete" &&
         createPortal(
           <AlertModal
-            isOpen={currentSheet === "delete"}
+            isOpen={sheet === "delete"}
             onClose={closeSheet}
             title="삭제할까요?"
             description={`그룹을 삭제하면 \n 저장된 가게 정보도 함께 삭제돼요`}
@@ -185,14 +194,14 @@ export default function SavedPageTemplate({
           />
         )}
 
-      {currentSheet === "edit" &&
+      {sheet === "edit" &&
         createPortal(
           <GroupWithInputBottomSheet
             title="그룹 수정"
             groupName={groupName}
-            selectedColor={selectedColor}
-            onGroupNameChange={handleGroupNameChange}
-            onColorSelect={handleColorSelect}
+            selectedColor={selectedIcon}
+            onGroupNameChange={setGroupName}
+            onColorSelect={setSelectedIcon}
             onClose={closeSheet}
             onDone={() => {
               closeSheet();
@@ -201,18 +210,22 @@ export default function SavedPageTemplate({
           />
         )}
 
-      {currentSheet === "create" &&
+      {sheet === "create" &&
         createPortal(
           <GroupWithInputBottomSheet
             title="새로운 그룹 만들기"
             groupName={groupName}
-            selectedColor={selectedColor}
-            onGroupNameChange={handleGroupNameChange}
-            onColorSelect={handleColorSelect}
+            selectedColor={selectedIcon}
+            onGroupNameChange={setGroupName}
+            onColorSelect={setSelectedIcon}
             onClose={closeSheet}
-            onDone={() => {
+            onDone={async () => {
+              if (!groupName || !selectedIcon) return;
+              await createGroupMutation.mutateAsync({
+                group_name: groupName,
+                icon: selectedIcon,
+              });
               closeSheet();
-              // TODO: 그룹 생성 로직 추가 필요
             }}
           />
         )}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,4 @@
+export * from "./useSheetState";
+export * from "./useSort";
+export * from "./useSelection";
+export * from "./usePortal";

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,3 +1,5 @@
 export * from "./useAutoCompleteQuery";
 export * from "./useInfiniteSearchQuery";
 export * from "./useVoteCountQuery";
+export * from "./useBookmarkedGroupsQuery";
+export * from "./useCreateGroupMutation";

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -3,3 +3,4 @@ export * from "./useInfiniteSearchQuery";
 export * from "./useVoteCountQuery";
 export * from "./useBookmarkedGroupsQuery";
 export * from "./useCreateGroupMutation";
+export * from "./useDeleteGroupMutation";

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -6,3 +6,4 @@ export * from "./useCreateGroupMutation";
 export * from "./useDeleteGroupMutation";
 export * from "./useBookmarkedPlacesQuery";
 export * from "./useDeleteBookmarkedPlaceMutation";
+export * from "./useMoveBookmarkedPlaceMutation";

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -4,3 +4,5 @@ export * from "./useVoteCountQuery";
 export * from "./useBookmarkedGroupsQuery";
 export * from "./useCreateGroupMutation";
 export * from "./useDeleteGroupMutation";
+export * from "./useBookmarkedPlacesQuery";
+export * from "./useDeleteBookmarkedPlaceMutation";

--- a/src/hooks/queries/useBookmarkedGroupsQuery.ts
+++ b/src/hooks/queries/useBookmarkedGroupsQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { getBookmarkedGroups } from "@/apis/activity";
+import type { GroupInfo } from "@/types/activity";
+
+export function useBookmarkedGroupsQuery(
+  options?: UseQueryOptions<{ total: number; groups: GroupInfo[] }>
+) {
+  return useQuery<{ total: number; groups: GroupInfo[] }>({
+    queryKey: ["bookmarkedGroups"],
+    queryFn: getBookmarkedGroups,
+    staleTime: 60 * 1000,
+    ...options,
+  });
+}

--- a/src/hooks/queries/useBookmarkedPlacesQuery.ts
+++ b/src/hooks/queries/useBookmarkedPlacesQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { getBookmarkedPlaces } from "@/apis/activity";
+import type { PlaceInfo } from "@/types/activity";
+
+export function useBookmarkedPlacesQuery(
+  id: string,
+  options?: UseQueryOptions<{
+    group_id: string;
+    group_name: string;
+    icon: string;
+    total: number;
+    places: PlaceInfo[];
+  }>
+) {
+  return useQuery<{
+    group_id: string;
+    group_name: string;
+    icon: string;
+    total: number;
+    places: PlaceInfo[];
+  }>({
+    queryKey: ["bookmarkedPlaces", id],
+    queryFn: () => getBookmarkedPlaces(id),
+    ...options,
+  });
+}

--- a/src/hooks/queries/useCreateGroupMutation.ts
+++ b/src/hooks/queries/useCreateGroupMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createGroup } from "@/apis/group";
+
+export function useCreateGroupMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createGroup,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedGroups"] });
+    },
+  });
+}

--- a/src/hooks/queries/useDeleteBookmarkedPlaceMutation.ts
+++ b/src/hooks/queries/useDeleteBookmarkedPlaceMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteBookmarkedPlace } from "@/apis/activity";
+
+export function useDeleteBookmarkedPlaceMutation(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (placeIds: string[]) =>
+      deleteBookmarkedPlace(groupId, placeIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["bookmarkedPlaces", groupId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedGroups"] });
+    },
+  });
+}

--- a/src/hooks/queries/useDeleteGroupMutation.ts
+++ b/src/hooks/queries/useDeleteGroupMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteGroup } from "@/apis/group";
+
+export function useDeleteGroupMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteGroup,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedGroups"] });
+    },
+  });
+}

--- a/src/hooks/queries/useMoveBookmarkedPlaceMutation.ts
+++ b/src/hooks/queries/useMoveBookmarkedPlaceMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { moveBookmarkedPlace } from "@/apis/activity";
+
+export function useMoveBookmarkedPlaceMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      sourceGroupId,
+      targetGroupIds,
+      placeIds,
+    }: {
+      sourceGroupId: string;
+      targetGroupIds: string[];
+      placeIds: string[];
+    }) => moveBookmarkedPlace(sourceGroupId, targetGroupIds, placeIds),
+    onSuccess: (_data, variables) => {
+      // invalidate both source and all target group places
+      queryClient.invalidateQueries({
+        queryKey: ["bookmarkedPlaces", variables.sourceGroupId],
+      });
+      variables.targetGroupIds.forEach((id) => {
+        queryClient.invalidateQueries({ queryKey: ["bookmarkedPlaces", id] });
+      });
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedGroups"] });
+    },
+  });
+}

--- a/src/hooks/queries/useUserVotedActivityQuery.ts
+++ b/src/hooks/queries/useUserVotedActivityQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getUserVotedActivity } from "@/apis/activity";
+
+export const useUserVotedActivityQuery = () => {
+  return useQuery({
+    queryKey: ["votedActivity"],
+    queryFn: getUserVotedActivity,
+  });
+};

--- a/src/hooks/useGroupManagement.ts
+++ b/src/hooks/useGroupManagement.ts
@@ -17,6 +17,7 @@ export function useGroupManagement() {
     onSuccess: () => {
       // 그룹 생성 성공 시 그룹 목록 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: ["PlaceGroup"] });
+      queryClient.invalidateQueries({ queryKey: ["bookmarkedGroups"] });
       setShowCreate(false);
     },
   });

--- a/src/hooks/usePlaceDetailPage.ts
+++ b/src/hooks/usePlaceDetailPage.ts
@@ -46,6 +46,7 @@ export function usePlaceDetailPage(placeId: string) {
     }) => patchPlatformMatchVote(placeId, { platform, reasons }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["voteSummary", placeId] });
+      queryClient.invalidateQueries({ queryKey: ["votedActivity"] });
     },
   });
 

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -1,0 +1,20 @@
+import { useState, useCallback } from "react";
+
+export function useSelection<T>(items: T[], getKey: (item: T) => string) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    const all = items.map(getKey);
+    setSelected((prev) => (prev.length === all.length ? [] : all));
+  }, [items, getKey]);
+
+  const reset = useCallback(() => setSelected([]), []);
+
+  return { selected, setSelected, toggle, toggleAll, reset };
+}

--- a/src/hooks/useSheetState.ts
+++ b/src/hooks/useSheetState.ts
@@ -1,0 +1,10 @@
+import { useState, useCallback } from "react";
+
+export function useSheetState<T extends string = string>() {
+  const [sheet, setSheet] = useState<T | null>(null);
+
+  const open = useCallback((key: T) => setSheet(key), []);
+  const close = useCallback(() => setSheet(null), []);
+
+  return { sheet, open, close };
+}

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,0 +1,16 @@
+import { useState, useMemo } from "react";
+
+export function useSort<T, K extends string>(
+  items: T[],
+  sorters: Record<K, (arr: T[]) => T[]>,
+  defaultKey?: K
+) {
+  const initialKey = defaultKey || (Object.keys(sorters)[0] as K);
+  const [sortKey, setSortKey] = useState<K>(initialKey);
+
+  const sortedItems = useMemo(() => {
+    return sorters[sortKey](items);
+  }, [items, sortKey, sorters]);
+
+  return { sortKey, setSortKey, sortedItems };
+}

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -39,6 +39,10 @@ export interface VotedActivityInfo {
   place_name: string;
   category: string;
   platform: string;
-  reasons: string[];
+  reasons: ("MANY_REVIEWS" | "DETAILED" | "HONEST" | "ACCURATE")[];
   voted_date: string;
+}
+
+export interface VotedActivityResponse {
+  data: VotedActivityInfo[];
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,27 @@
+export function parseKoreanDateInfo(utcString: string) {
+  const date = new Date(utcString);
+  const now = new Date();
+
+  // 년, 월, 일
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  // 요일 (한글)
+  const dayOfWeek = date.toLocaleDateString("ko-KR", { weekday: "long" });
+
+  // 오늘 여부
+  const isToday =
+    year === now.getFullYear() &&
+    month === now.getMonth() + 1 &&
+    day === now.getDate();
+
+  return {
+    year,
+    month,
+    date: day,
+    day: dayOfWeek,
+    isToday,
+    dateObj: date,
+  };
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 어떤 내용인지 간단히 설명해주세요 -->
유저의 활동데이터 저장그룹/투표내역에 대한 api 연동 작업 진행

## 🔍 변경 사항

<!-- 이 PR에서 변경된 내용을 상세히 설명해주세요 -->

- [x] 이동 api 연결
- [x] 장소 삭제 api 연결
- [x] 그룹 삭제 api 연결
- [x] 생성 api 연결
- [x] 투표 데이터 조회
- [x] 투표 데이터 정렬

그룹 편집 api 구현 누락으로 추후 추가 예정

## 📸 스크린샷

<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 입력해주세요 -->

Closes: #43

## 📝 추가 설명

<!-- 추가로 설명이 필요한 사항이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced hooks and API integrations for managing bookmarked groups and places, including creating, deleting, and moving items.
  * Added support for fetching and displaying user voted activities with enhanced grouping and sorting options.
  * Implemented new utility functions for date parsing and selection management.

* **Enhancements**
  * Refactored saved and voted pages to use React Query for data fetching, caching, and hydration, improving performance and data consistency.
  * Updated group and place management interfaces for better state handling and user feedback.
  * Improved error handling and cache invalidation to ensure UI reflects the latest data.

* **Bug Fixes**
  * Adjusted button states to ensure required fields are selected before enabling actions.

* **Style**
  * Enhanced display of grouped activity lists and improved label formatting.

* **Chores**
  * Removed unnecessary debug statements and consolidated hook exports for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->