### PR TITLE
[FIX] QA 수정사항 - 모달, Toast, 로그인, 지역설정, 가게상세

### DIFF
--- a/src/store/useRegionStore.ts
+++ b/src/store/useRegionStore.ts
@@ -3,11 +3,11 @@ import { persist } from "zustand/middleware";
 import { RegionState } from "@/types/region";
 import { getDongListByCity } from "@/utils/regionUtils";
 
-// 초기 상태를 null로 설정
+// 초기 상태를 빈 값으로 설정
 const initialState = {
-  province: null as string | null,
-  city: null as string | null,
-  dong: null as { name: string; dong_code: string }[] | null,
+  province: "",
+  city: "",
+  dong: [] as { name: string; dong_code: string }[],
   isDongAllSelected: false,
 };
 
@@ -30,7 +30,7 @@ const useRegionStore = create<RegionState>()(
       // 초기화 함수 추가
       initializeRegion: () => {
         const state = get();
-        if (!state.province || !state.city || !state.dong) {
+        if (!state.province || !state.city || state.dong.length === 0) {
           set({
             province: "서울",
             city: "강남구",
@@ -44,7 +44,10 @@ const useRegionStore = create<RegionState>()(
       name: "region-storage",
       // 초기값이 없을 때만 기본값 사용
       onRehydrateStorage: () => (state) => {
-        if (state && (!state.province || !state.city || !state.dong)) {
+        if (
+          state &&
+          (!state.province || !state.city || state.dong.length === 0)
+        ) {
           state.province = "서울";
           state.city = "강남구";
           state.dong = getDongListByCity("강남구");

--- a/src/types/region.ts
+++ b/src/types/region.ts
@@ -17,9 +17,9 @@ export interface Province {
 }
 
 export interface RegionState {
-  province: string | null;
-  city: string | null;
-  dong: DongInfo[] | null;
+  province: string;
+  city: string;
+  dong: DongInfo[];
   isDongAllSelected: boolean;
   setRegion: (
     province: string,


### PR DESCRIPTION
## 📝 PR 개요

QA 수정사항 적용

## 🔍 변경 사항

<!-- 이 PR에서 변경된 내용을 상세히 설명해주세요 -->

- [x] 모달 오버레이 범위 수정
- [x] Toast width 수정
- [x] 그룹만들기모달 showoverlay 옵션 추가
- [x] 로그인요청시 리다이렉트 추가
- [x] 기본 지역설정 및 지역설정변경시 지역설정 유지 로직 추가
- [x] 가게상세 이미지없을시 기본이미지 추가
- [x] 그룹만들기 글자 크기수정
## 🧪 테스트

<!-- 테스트한 내용을 설명해주세요 -->


## 📸 스크린샷

<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 입력해주세요 -->

Closes #46 

## 📝 추가 설명
실수로 한번 main push 해버림.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of region selection state by using empty strings and arrays instead of null values for province, city, and dong fields. This ensures more consistent behavior when regions are uninitialized. No changes to the user interface or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->