### PR TITLE
[FEAT] AI 요약 브랜드 키워드 하이라이트

### DIFF
--- a/src/components/atoms/MultiKeywordHighlighter/MultiKeywordHighlighter.stories.tsx
+++ b/src/components/atoms/MultiKeywordHighlighter/MultiKeywordHighlighter.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import MultiKeywordHighlighter from "./MultiKeywordHighlighter";
+
+const meta: Meta<typeof MultiKeywordHighlighter> = {
+  title: "Atoms/MultiKeywordHighlighter",
+  component: MultiKeywordHighlighter,
+  tags: ["autodocs"],
+  argTypes: {
+    text: {
+      control: "text",
+      description: "원본 텍스트",
+    },
+    highlights: {
+      control: "object",
+      description:
+        "하이라이트 설정 배열. 예: [{ word: '네이버', color: '#03C75A' }]",
+    },
+    caseSensitive: {
+      control: "boolean",
+      description: "대소문자 구분 여부 (기본 true)",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MultiKeywordHighlighter>;
+
+export const Default: Story = {
+  args: {
+    text: "네이버와 카카오, 네이버지도와 카카오맵을 비교합니다.",
+    highlights: [
+      { word: "네이버", color: "#03C75A" },
+      { word: "카카오", color: "#FEE500" },
+    ],
+  },
+};
+
+export const CaseInsensitive: Story = {
+  args: {
+    text: "Naver와 KAkaO를 비교합니다. NAVER 서비스와 kakao 서비스",
+    highlights: [
+      { word: "naver", color: "#03C75A" },
+      { word: "kakao", color: "#FEE500" },
+    ],
+    caseSensitive: false,
+  },
+};
+
+export const OverlapPriority: Story = {
+  args: {
+    text: "네이버지도와 네이버는 다르게 매칭됩니다.",
+    highlights: [
+      { word: "네이버지도", color: "#00AA88" },
+      { word: "네이버", color: "#03C75A" },
+    ],
+  },
+};
+
+export const WithCustomStyle: Story = {
+  args: {
+    text: "강조 색상과 굵기를 함께 적용합니다: 네이버, 카카오",
+    highlights: [
+      { word: "네이버", color: "#03C75A", className: "font-semibold" },
+      {
+        word: "카카오",
+        color: "#F59E0B",
+        style: { textDecoration: "underline" },
+      },
+    ],
+  },
+};

--- a/src/components/atoms/MultiKeywordHighlighter/MultiKeywordHighlighter.tsx
+++ b/src/components/atoms/MultiKeywordHighlighter/MultiKeywordHighlighter.tsx
@@ -1,0 +1,84 @@
+import React, { useMemo } from "react";
+
+type Highlight = {
+  word: string;
+  color: string;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+interface MultiKeywordHighlighterProps {
+  text: string;
+  highlights: Highlight[]; // [{ word: "네이버", color: "#03C75A" }, ...]
+  caseSensitive?: boolean; // 기본 true
+}
+
+function escapeRegExp(str: string) {
+  // 정규식 메타문자 이스케이프
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export default function MultiKeywordHighlighter({
+  text,
+  highlights,
+  caseSensitive = true,
+}: MultiKeywordHighlighterProps) {
+  const { regex, mapByWord } = useMemo(() => {
+    if (!highlights?.length) {
+      return {
+        regex: null as RegExp | null,
+        mapByWord: new Map<string, Highlight>(),
+      };
+    }
+
+    // 길이 내림차순 정렬 → 더 긴 키워드가 먼저 매칭(부분 중첩 완화)
+    const sorted = [...highlights].sort(
+      (a, b) => b.word.length - a.word.length
+    );
+
+    // word -> 설정 맵
+    const m = new Map<string, Highlight>();
+    sorted.forEach((h) => m.set(h.word, h));
+
+    // 정규식 생성
+    const pattern = `(${sorted.map((h) => escapeRegExp(h.word)).join("|")})`;
+    const flags = `g${caseSensitive ? "" : "i"}`;
+    return { regex: new RegExp(pattern, flags), mapByWord: m };
+  }, [highlights, caseSensitive]);
+
+  if (!regex) return <>{text}</>;
+
+  // split으로 캡처그룹을 포함해서 쪼갬 → 매칭된 단어가 배열에 그대로 들어옴
+  const parts = text.split(regex);
+
+  return (
+    <>
+      {parts.map((part, idx) => {
+        if (!part) return null;
+
+        // caseSensitive=false일 때는 원문(part)와 동일한 키를 못 찾을 수 있으므로
+        // 하이라이트 목록에서 대소문자 무시 비교로 다시 찾음
+        const matched = [...mapByWord.keys()].find((key) =>
+          caseSensitive
+            ? key === part
+            : key.toLowerCase() === part.toLowerCase()
+        );
+
+        if (matched) {
+          const conf = mapByWord.get(matched)!;
+          return (
+            <span
+              key={idx}
+              className={conf.className}
+              style={{ color: conf.color, ...conf.style }}
+            >
+              {part}
+            </span>
+          );
+        }
+
+        return <React.Fragment key={idx}>{part}</React.Fragment>;
+      })}
+    </>
+  );
+}

--- a/src/components/organisms/AISummary/AISummary.tsx
+++ b/src/components/organisms/AISummary/AISummary.tsx
@@ -2,6 +2,8 @@
 
 import Tabs from "@/components/organisms/Tabs/Tabs";
 import BarGraph from "@/components/molecules/BarGraph/BarGraph";
+import MultiKeywordHighlighter from "@/components/atoms/MultiKeywordHighlighter/MultiKeywordHighlighter";
+import { colors } from "@/styles/colors";
 
 interface AISummaryProps {
   summaryAi: string;
@@ -19,13 +21,19 @@ export default function AISummary({ summaryAi, strengths }: AISummaryProps) {
     content: (
       <div className="flex flex-col w-full gap-[24px]">
         {summaryAi ? (
-          <p className="body-m-semibold px-[16px] pt-[12px] text-left">
-            {summaryAi}
-          </p>
+          <div className="body-m-semibold px-[16px] pt-[12px] text-left">
+            <MultiKeywordHighlighter
+              text={summaryAi}
+              highlights={[
+                { word: "카카오", color: colors.Brand.KaKao.Blue },
+                { word: "네이버", color: colors.Brand.Naver.Main },
+              ]}
+            />
+          </div>
         ) : (
-          <p className="body-m-semibold px-[16px] pt-[12px] text-texticon-onnormal-lowestemp text-left">
+          <span className="body-m-semibold px-[16px] pt-[12px] text-texticon-onnormal-lowestemp text-left">
             AI요약을 위한 리뷰 데이터가 부족해요
-          </p>
+          </span>
         )}
         <div className="flex justify-center">
           <BarGraph


### PR DESCRIPTION
## 📝 PR 개요
> - AI 요약 부분에 “네이버” 와 “카카오” 단어에 각각 초록색, 노란색 브랜드 색상을 주기.
    - 받은 피드백 : AI 요약 리뷰 읽는게 귀찮음. 네이버랑 카카오 리뷰 구분이 필요함. 처음에 카카오는 없지? 싶었음. 문장형을 선호하지 않음.
    - 받은 피드백 : AI 리뷰랑 실제 리뷰가 매치하지않음. 신뢰도가 떨어짐.
<!-- 이 PR이 어떤 내용인지 간단히 설명해주세요 -->

## 🔍 변경 사항

<!-- 이 PR에서 변경된 내용을 상세히 설명해주세요 -->

- [x] 멀티 키워드 하이라이트 기능 추가
- [x] AI요약 컴포넌트에 적용

## 🧪 테스트

<!-- 테스트한 내용을 설명해주세요 -->

- [ ] 테스트 케이스 1
- [ ] 테스트 케이스 2

## 📸 스크린샷

<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 입력해주세요 -->

Closes #50
## 📝 추가 설명

<!-- 추가로 설명이 필요한 사항이 있다면 작성해주세요 -->
