### PR TITLE
[FEAT] 유저 활동 캘린더 기능 개발

### DIFF
--- a/src/apis/activity.ts
+++ b/src/apis/activity.ts
@@ -87,19 +87,22 @@ export const moveBookmarkedPlace = async (
   }
 };
 
-export const getUserVotedActivity = async () => {
+export const getActivityCalendar = async (year: number, month: number) => {
   try {
     let data;
     if (typeof window === "undefined") {
-      data = await fetchWithAuth<VotedActivityResponse>(`/users/activity/vote`);
+      data = await fetchWithAuth<VotedActivityResponse>(
+        `/users/activity/calendar?year=${year}&month=${month}`
+      );
       return data.data;
     } else {
-      const response =
-        await authProxyAPI.get<VotedActivityResponse>(`/users/activity/vote`);
+      const response = await authProxyAPI.get<VotedActivityResponse>(
+        `/users/activity/calendar?year=${year}&month=${month}`
+      );
       return response.data.data;
     }
   } catch (error) {
-    console.error("Failed to fetch user voted activity:", error);
+    console.error("Failed to fetch user calendar activity:", error);
     throw error;
   }
 };

--- a/src/app/(user)/voted/page.tsx
+++ b/src/app/(user)/voted/page.tsx
@@ -1,4 +1,4 @@
-import { getUserVotedActivity } from "@/apis/activity";
+import { getActivityCalendar } from "@/apis/activity";
 import VotedPageTemplate from "@/components/templates/VotedPageTemplate/VotedPageTemplate";
 import {
   dehydrate,
@@ -6,14 +6,17 @@ import {
   QueryClient,
 } from "@tanstack/react-query";
 import { requireLogin } from "../requireLogin";
+import { parseKoreanDateInfo } from "@/utils/date";
 
 export default async function VotedPage() {
   await requireLogin(`/voted`);
 
   const queryClient = new QueryClient();
+  const date = parseKoreanDateInfo(new Date().toISOString());
+
   await queryClient.prefetchQuery({
     queryKey: ["votedActivity"],
-    queryFn: getUserVotedActivity,
+    queryFn: () => getActivityCalendar(date.year, date.month),
   });
   const dehydratedState = dehydrate(queryClient);
   return (

--- a/src/components/atoms/Icon/icons/ChevronRight.tsx
+++ b/src/components/atoms/Icon/icons/ChevronRight.tsx
@@ -1,0 +1,19 @@
+import { colors } from "@/styles/colors";
+import { SVGProps } from "react";
+
+export default function ChevronRight(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width={props.width}
+      height={props.height}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M13.57 10.3763L6.82925 16.2744C6.50596 16.5573 6 16.3277 6 15.8981L6 4.10188C6 3.67231 6.50596 3.44271 6.82925 3.7256L13.57 9.62371C13.7976 9.82292 13.7976 10.1771 13.57 10.3763Z"
+        fill={props.fill || colors.TextIcon.OnNormal.LowestEmp}
+      />
+    </svg>
+  );
+}

--- a/src/components/atoms/Icon/icons/index.ts
+++ b/src/components/atoms/Icon/icons/index.ts
@@ -43,3 +43,4 @@ export { default as Empty } from "./Empty";
 export { default as VoteReslutLeft } from "./VoteReslutLeft";
 export { default as VoteReslutRight } from "./VoteReslutRight";
 export { default as PopupExit } from "./PopupExit";
+export { default as ChevronRight } from "./ChevronRight";

--- a/src/components/organisms/ActivityCalendar/ActivityCalendar.tsx
+++ b/src/components/organisms/ActivityCalendar/ActivityCalendar.tsx
@@ -1,0 +1,187 @@
+import Icon from "@/components/atoms/Icon/Icon";
+import IconButton from "@/components/molecules/IconButton/IconButton";
+import type { VotedActivityInfo } from "@/types/activity";
+import { cn } from "@/utils/cn";
+import { parseKoreanDateInfo } from "@/utils/date";
+
+interface ActivityCalendarProps {
+  year: number;
+  month: number;
+  votes: VotedActivityInfo[];
+  selectedDate: string | null;
+  onChangeMonth: (year: number, month: number) => void;
+  onDateClick: (date: string) => void;
+}
+
+export default function ActivityCalendar({
+  year,
+  month,
+  votes,
+  selectedDate,
+  onChangeMonth,
+  onDateClick,
+}: ActivityCalendarProps) {
+  const monthForDate = month - 1;
+
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const currentMonth = currentDate.getMonth() + 1;
+
+  const isPrevDisabled = year === 2025 && month === 7;
+  const isNextDisabled = year === currentYear && month >= currentMonth;
+
+  const firstDayOfMonth = new Date(year, monthForDate, 1);
+  const startDay = new Date(firstDayOfMonth);
+  startDay.setDate(1 - firstDayOfMonth.getDay());
+
+  const lastDayOfMonth = new Date(year, monthForDate + 1, 0);
+  const endDay = new Date(lastDayOfMonth);
+  endDay.setDate(lastDayOfMonth.getDate() + (6 - lastDayOfMonth.getDay()));
+
+  const groupDatesByWeek = (startDay: Date, endDay: Date) => {
+    const weeks = [];
+    let currentWeek = [];
+    const currentDate = new Date(startDay);
+
+    while (currentDate <= endDay) {
+      currentWeek.push(new Date(currentDate));
+      if (currentWeek.length === 7 || currentDate.getDay() === 6) {
+        weeks.push(currentWeek);
+        currentWeek = [];
+      }
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    if (currentWeek.length > 0) {
+      weeks.push(currentWeek);
+    }
+
+    return weeks;
+  };
+
+  const handlePrevMonth = () => {
+    if (isPrevDisabled) return;
+
+    if (month === 1) {
+      onChangeMonth(year - 1, 12);
+    } else {
+      onChangeMonth(year, month - 1);
+    }
+  };
+
+  const handleNextMonth = () => {
+    if (isNextDisabled) return;
+
+    if (month === 12) {
+      onChangeMonth(year + 1, 1);
+    } else {
+      onChangeMonth(year, month + 1);
+    }
+  };
+
+  const weeks = groupDatesByWeek(startDay, endDay);
+
+  return (
+    <div className="flex flex-col gap-4 mt-[32px] mb-[24px] px-[16px]">
+      {/* 월 변경 헤더 */}
+      <div className="flex items-center justify-center gap-2 mb-[24px]">
+        <IconButton
+          startIcon={<Icon icon="ChevronRight" size={20} />}
+          onClick={handlePrevMonth}
+          disabled={isPrevDisabled}
+          className={cn("rotate-180", isPrevDisabled && "disabled:opacity-50")}
+        />
+
+        <h2 className="w-[90px] text-center body-m-regular text-texticon-onnormal-highestemp">
+          {year}년 {String(month).padStart(2)}월
+        </h2>
+        <IconButton
+          endIcon={<Icon icon="ChevronRight" size={20} />}
+          onClick={handleNextMonth}
+          disabled={isNextDisabled}
+          className={cn(isNextDisabled && "disabled:opacity-50")}
+        />
+      </div>
+
+      {/* 요일 헤더 */}
+      <div className="grid grid-cols-7 gap-1 text-center caption-m-semibold text-texticon-onnormal-lowemp mb-[8px]">
+        <div>일</div>
+        <div>월</div>
+        <div>화</div>
+        <div>수</div>
+        <div>목</div>
+        <div>금</div>
+        <div>토</div>
+      </div>
+
+      {/* 달력 그리드 */}
+      <div className="grid grid-cols-7 gap-0 rounded-lg overflow-hidden">
+        {weeks.flat().map((date, index) => {
+          const isCurrentMonth = date.getMonth() === monthForDate;
+
+          const isToday =
+            date.getFullYear() === currentYear &&
+            date.getMonth() === currentMonth - 1 &&
+            date.getDate() === currentDate.getDate();
+
+          const hasActivity = votes.filter((vote) => {
+            const voteDateInfo = parseKoreanDateInfo(vote.voted_date);
+
+            return (
+              voteDateInfo.year === date.getFullYear() &&
+              voteDateInfo.month === date.getMonth() + 1 &&
+              voteDateInfo.date === date.getDate()
+            );
+          });
+
+          return (
+            <div
+              key={date.toISOString()}
+              className={cn(
+                "aspect-square flex flex-col items-center justify-start body-s-semibold relative px-[4px] pt-[12px] pb-[8px]",
+                index >= 7 && "border-t-[0.5px] border-border-normal-lowestemp",
+                isCurrentMonth
+                  ? "text-texticon-onnormal-highestemp"
+                  : "text-texticon-onnormal-lowestemp",
+                isToday && "text-texticon-onnormal-main-500"
+              )}
+              onClick={
+                hasActivity.length > 0
+                  ? () => onDateClick(date.toISOString())
+                  : undefined
+              }
+            >
+              <span
+                className={cn(
+                  "w-[22px] h-[22px] flex items-center justify-center",
+                  selectedDate === date.toISOString() &&
+                    "text-texticon-onnormal-white bg-texticon-onnormal-highestemp rounded-[4px]"
+                )}
+              >
+                {date.getDate()}
+              </span>
+
+              <div className="grid grid-cols-3 gap-[4px] py-[4px] justify-items-center min-h-[26px]">
+                {Array.from({ length: Math.min(hasActivity.length, 9) }).map(
+                  (_, index) => (
+                    <div
+                      key={index}
+                      className={cn(
+                        "w-[6px] h-[6px] rounded-full",
+                        isToday
+                          ? "bg-brand-primary-main"
+                          : selectedDate === date.toISOString()
+                            ? "bg-texticon-onnormal-highestemp"
+                            : "bg-texticon-onnormal-lowestemp"
+                      )}
+                    />
+                  )
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/queries/useUserVotedActivityQuery.ts
+++ b/src/hooks/queries/useUserVotedActivityQuery.ts
@@ -1,9 +1,36 @@
-import { useQuery } from "@tanstack/react-query";
-import { getUserVotedActivity } from "@/apis/activity";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getActivityCalendar } from "@/apis/activity";
+import { useEffect } from "react";
 
-export const useUserVotedActivityQuery = () => {
-  return useQuery({
-    queryKey: ["votedActivity"],
-    queryFn: getUserVotedActivity,
+export const useUserVotedActivityQuery = (year: number, month: number) => {
+  const queryClient = useQueryClient();
+
+  // 현재 달 데이터
+  const query = useQuery({
+    queryKey: ["votedActivity", year, month],
+    queryFn: () => getActivityCalendar(year, month),
+    staleTime: 1000 * 60 * 60 * 24,
   });
+
+  // 이전달 / 다음달 prefetch
+  useEffect(() => {
+    const prev =
+      month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+    const next =
+      month === 12 ? { year: year + 1, month: 1 } : { year, month: month + 1 };
+
+    queryClient.prefetchQuery({
+      queryKey: ["votedActivity", prev.year, prev.month],
+      queryFn: () => getActivityCalendar(prev.year, prev.month),
+      staleTime: 1000 * 60 * 60 * 24,
+    });
+
+    queryClient.prefetchQuery({
+      queryKey: ["votedActivity", next.year, next.month],
+      queryFn: () => getActivityCalendar(next.year, next.month),
+      staleTime: 1000 * 60 * 60 * 24,
+    });
+  }, [year, month, queryClient]);
+
+  return query;
 };

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -44,5 +44,7 @@ export interface VotedActivityInfo {
 }
 
 export interface VotedActivityResponse {
-  data: VotedActivityInfo[];
+  data: {
+    votes: VotedActivityInfo[];
+  };
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,16 +1,15 @@
 export function parseKoreanDateInfo(utcString: string) {
   const date = new Date(utcString);
+
+  const koreaDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
   const now = new Date();
 
-  // 년, 월, 일
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  const year = koreaDate.getFullYear();
+  const month = koreaDate.getMonth() + 1;
+  const day = koreaDate.getDate();
 
-  // 요일 (한글)
-  const dayOfWeek = date.toLocaleDateString("ko-KR", { weekday: "long" });
+  const dayOfWeek = koreaDate.toLocaleDateString("ko-KR", { weekday: "long" });
 
-  // 오늘 여부
   const isToday =
     year === now.getFullYear() &&
     month === now.getMonth() + 1 &&
@@ -22,6 +21,6 @@ export function parseKoreanDateInfo(utcString: string) {
     date: day,
     day: dayOfWeek,
     isToday,
-    dateObj: date,
+    dateObj: koreaDate,
   };
 }


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 어떤 내용인지 간단히 설명해주세요 -->
투표활동내역에 대한 캘린더 UI 제공

## 🔍 변경 사항

<!-- 이 PR에서 변경된 내용을 상세히 설명해주세요 -->

- [x] 기존 전체 투표내역 조회 api에서 월별 투표내역 조회 api로 교체
- [x] 자체 ActivityCalendar 구현
- [x] 유틸 함수를 통해 투표 데이터 UTC -> KST로 변환 후 캘린더 반영

## 📸 스크린샷

<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 입력해주세요 -->

Closes #52 

## 📝 추가 설명

<!-- 추가로 설명이 필요한 사항이 있다면 작성해주세요 -->
추후 메인 화면 캘린더 버튼 disable 해제 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a monthly Activity Calendar with previous/next navigation.
  - Enabled date selection to filter and highlight voted activities.
  - Introduced a Chevron Right icon for calendar navigation.

- Enhancements
  - Updated the voted activities list to group by date and reflect selected/today states.
  - Displayed counts now adapt to the selected date.
  - Prefetches adjacent months for faster calendar browsing.
  - Improved Korea Standard Time handling for dates.

- Bug Fixes
  - Clarified error messaging when loading calendar activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->